### PR TITLE
Change min support version for sha2 from v0.10.9 to v0.10.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "derive_more 2.0.1",
  "either",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -948,7 +948,7 @@ dependencies = [
  "lcp-types",
  "prost",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1371,7 +1371,7 @@ dependencies = [
  "milagro_bls",
  "primitive-types",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "ssz-rs",
  "ssz-rs-derive",
 ]
@@ -1696,7 +1696,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "subtle-encoding",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -1735,7 +1735,7 @@ dependencies = [
  "hex",
  "prost",
  "ripemd",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sha3",
 ]
 
@@ -1828,7 +1828,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "serdect",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2172,7 +2172,7 @@ dependencies = [
  "ff",
  "hex",
  "serde_arrays",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "sp1_bls12_381",
  "spin 0.9.8",
 ]
@@ -2600,7 +2600,7 @@ dependencies = [
  "prost-derive",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
 ]
 
@@ -2649,7 +2649,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3225,7 +3225,7 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3567,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3654,7 +3654,7 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3874,7 +3874,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.10.9",
+ "sha2 0.10.8",
  "signature 1.6.4",
  "subtle",
  "subtle-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ alloy-evm = { version = "0.10.0", default-features = false, features = ["op"] }
 alloy-op-evm = { version = "0.10.0", default-features = false }
 
 # Cryptography
-sha2 = { version = "0.10.9", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 c-kzg = { version = "2.1.1", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
 secp256k1 = { version = "0.31.0", default-features = false }


### PR DESCRIPTION
https://github.com/op-rs/kona/blob/4dc0adec86014980bfd2eb24cd7ce14a64221aef/Cargo.toml#L258

https://github.com/op-rs/kona/blob/62a4ff9c0e6ac97b0993aba5b8e181be295b38b4/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs#L51

sha2 v0.10.9 is specified for kona, but this is only used in the test code and v0.10.8 works fine, so v0.10.8 should be used.