### PR TITLE
Feature/logging

### DIFF
--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -6,7 +6,7 @@ use crate::header::Header;
 use crate::message::ClientMessage;
 use crate::misbehaviour::Misbehaviour;
 use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{format, vec};
 use alloc::vec::Vec;
 use alloy_primitives::keccak256;
 use core::time::Duration;
@@ -21,6 +21,7 @@ use light_client::{
     CreateClientResult, Error as LightClientError, HostClientReader, LightClient, MisbehaviourData,
     UpdateClientResult, UpdateStateData, VerifyMembershipResult, VerifyNonMembershipResult,
 };
+use crate::logger;
 
 pub struct OptimismLightClient<const L1_SYNC_COMMITTEE_SIZE: usize>;
 
@@ -86,6 +87,7 @@ impl<const L1_SYNC_COMMITTEE_SIZE: usize> LightClient
         client_id: ClientId,
         client_message: Any,
     ) -> Result<UpdateClientResult, light_client::Error> {
+        logger::info(&format!("update_client {}", client_id.to_string()));
         match ClientMessage::<L1_SYNC_COMMITTEE_SIZE>::try_from(client_message.clone())? {
             ClientMessage::Header(header) => Ok(self.update_state(ctx, client_id, header)?.into()),
             ClientMessage::Misbehaviour(misbehaviour) => Ok(self
@@ -173,6 +175,7 @@ impl<const L1_SYNC_COMMITTEE_SIZE: usize> OptimismLightClient<L1_SYNC_COMMITTEE_
         client_id: ClientId,
         header: Header<L1_SYNC_COMMITTEE_SIZE>,
     ) -> Result<UpdateStateData, Error> {
+        logger::info(&format!("update_state {} trusted_height={}", client_id.to_string(), header.trusted_height.revision_height()));
         let trusted_height = header.trusted_height;
         let any_client_state = ctx.client_state(&client_id).map_err(Error::LCPError)?;
         let any_consensus_state = ctx

--- a/light-client/src/client_state.rs
+++ b/light-client/src/client_state.rs
@@ -8,6 +8,7 @@ use crate::misc::{
     validate_state_timestamp_within_trusting_period,
 };
 use alloc::borrow::ToOwned;
+use alloc::format;
 use alloc::vec::Vec;
 use alloy_primitives::B256;
 use ethereum_consensus::beacon::Version;
@@ -25,6 +26,7 @@ use optimism_ibc_proto::ibc::lightclients::ethereum::v1::{
 use optimism_ibc_proto::ibc::lightclients::optimism::v1::ClientState as RawClientState;
 use optimism_ibc_proto::ibc::lightclients::optimism::v1::L1Config as RawL1Config;
 use prost::Message;
+use crate::logger;
 
 pub const OPTIMISM_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.optimism.v1.ClientState";
 
@@ -70,6 +72,7 @@ impl ClientState {
         trusted_consensus_state: &ConsensusState,
         header: Header<L1_SYNC_COMMITTEE_SIZE>,
     ) -> Result<(ClientState, ConsensusState, Height), Error> {
+        logger::info(&format!("check_header_and_update_state trusted_height={}", header.trusted_height.revision_height()));
         // Since the L1 block hash is used for L2 derivation, the validity of L1 must be verified.
         let l1_consensus = header.verify_l1(
             &self.l1_config,

--- a/light-client/src/lib.rs
+++ b/light-client/src/lib.rs
@@ -15,6 +15,7 @@ mod commitment;
 pub mod errors;
 pub mod header;
 mod l1;
+mod logger;
 mod message;
 mod misbehaviour;
 mod misc;

--- a/light-client/src/logger.rs
+++ b/light-client/src/logger.rs
@@ -1,7 +1,3 @@
-#![no_std]
-#[macro_use]
-extern crate alloc;
-
 use alloc::vec::Vec;
 
 extern "C" {

--- a/light-client/src/logger.rs
+++ b/light-client/src/logger.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#[macro_use]
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+extern "C" {
+    fn ocall_info(msg: *const i8);
+    fn ocall_debug(msg: *const i8);
+}
+
+#[no_mangle]
+pub extern "C" fn info(msg: &str) {
+    let mut buf: Vec<u8> = msg.as_bytes().to_vec();
+    buf.push(0); // Append NUL terminator
+
+    unsafe {
+        ocall_info(buf.as_ptr() as *const i8);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn debug(msg: &str) {
+    let mut buf: Vec<u8> = msg.as_bytes().to_vec();
+    buf.push(0); // Append NUL terminator
+
+    unsafe {
+        ocall_debug(buf.as_ptr() as *const i8);
+    }
+}


### PR DESCRIPTION
Output enclave log on LCP to debug SGX error (e.g SGX_ERROR_ENCLAVE_CRASHED)

```
[2025-08-11T12:42:23Z INFO  host::ocalls] enclave: update_client optimism-1
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: update_state optimism-1 trusted_height=3977
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: check_header_and_update_state trusted_height=3977
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: verify l1 trusted_to_deterministic index=0 number=1343
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: verify l1 trusted_to_deterministic index=1 number=1343
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: verify l1 deterministic_to_latest index=0 number=1407
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: verify l1 deterministic_to_latest index=1 number=1407
[2025-08-11T12:42:24Z INFO  host::ocalls] enclave: verify l2 derivation=4027
```