### PR TITLE
chore: bump kona to kona-node/v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "num_enum",
  "serde",
  "strum",
@@ -68,14 +68,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
+checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
@@ -93,15 +93,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
+checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -111,7 +111,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "crc",
  "serde",
@@ -124,7 +124,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "serde",
 ]
@@ -135,7 +135,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "k256",
  "serde",
@@ -144,14 +144,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -164,7 +165,7 @@ dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-eip7928",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "auto_impl",
@@ -177,17 +178,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c0456f5f7a4497e9342d20f528e30f5288ddfa0d6a012bd5044afee46cd8a0"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-eip7928",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "auto_impl",
  "c-kzg",
  "derive_more 2.1.1",
@@ -204,10 +205,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
- "alloy-primitives 1.5.7",
- "alloy-sol-types 1.5.7",
+ "alloy-primitives 1.6.0",
+ "alloy-sol-types 1.6.0",
  "auto_impl",
  "derive_more 2.1.1",
  "revm",
@@ -217,13 +218,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71ff8b55d2b8aa05259f474cae7dea0e4991724dc18936b81cb23ec492a0c2a"
+checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
- "alloy-serde 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "serde",
 ]
@@ -236,7 +237,7 @@ checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -244,27 +245,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
+checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
- "alloy-serde 2.0.4",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "op-alloy",
  "op-revm",
@@ -275,11 +276,11 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "auto_impl",
  "serde",
 ]
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -312,7 +313,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.1.1",
  "foldhash",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.0",
  "indexmap",
  "itoa",
  "k256",
@@ -321,7 +322,7 @@ dependencies = [
  "ruint",
  "rustc-hash",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -348,15 +349,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b12366c96f4013e1aeebc96c6b56e5f33f07853c42ea2f485045c0c157a4a1"
+checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "derive_more 2.1.1",
  "rand 0.8.5",
  "serde",
@@ -365,18 +366,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-network-primitives",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde 2.0.4",
- "alloy-sol-types 1.5.7",
+ "alloy-serde 2.0.5",
+ "alloy-sol-types 1.6.0",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -389,18 +390,18 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eada2558e921b39dfcead33c487364df9b31374f5733c1c9d2c891c4529933"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "serde",
  "serde_json",
 ]
@@ -421,12 +422,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
- "alloy-sol-macro-expander 1.5.7",
- "alloy-sol-macro-input 1.5.7",
+ "alloy-sol-macro-expander 1.6.0",
+ "alloy-sol-macro-input 1.6.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -453,20 +454,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
- "alloy-sol-macro-input 1.5.7",
+ "alloy-sol-macro-input 1.6.0",
  "const-hex",
  "heck",
  "indexmap",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.11.0",
  "syn 2.0.104",
- "syn-solidity 1.5.7",
+ "syn-solidity 1.6.0",
 ]
 
 [[package]]
@@ -478,7 +479,7 @@ dependencies = [
  "const-hex",
  "dunce",
  "heck",
- "macro-string",
+ "macro-string 0.1.4",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -487,18 +488,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
  "heck",
- "macro-string",
+ "macro-string 0.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
- "syn-solidity 1.5.7",
+ "syn-solidity 1.6.0",
 ]
 
 [[package]]
@@ -514,12 +515,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
- "alloy-primitives 1.5.7",
- "alloy-sol-macro 1.5.7",
+ "alloy-primitives 1.6.0",
+ "alloy-sol-macro 1.6.0",
 ]
 
 [[package]]
@@ -528,7 +529,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "derive_more 2.1.1",
  "nybbles",
@@ -540,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0350197dcd4ba4e9a7dd43915d908c0eb0e7352755791709a705e1c76b6"
+checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -867,6 +868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1164,6 +1174,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1387,8 +1406,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1789,7 +1818,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
- "serde",
 ]
 
 [[package]]
@@ -1797,6 +1825,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -1859,6 +1892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "ibc"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,7 +1960,7 @@ dependencies = [
  "prost",
  "ripemd",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -2025,15 +2067,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "kona-client"
 version = "1.0.2"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-op-evm",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
@@ -2066,11 +2118,11 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
@@ -2088,11 +2140,11 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "async-trait",
  "kona-derive",
@@ -2109,14 +2161,14 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie",
  "kona-genesis",
@@ -2133,16 +2185,16 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.7",
- "alloy-sol-types 1.5.7",
+ "alloy-primitives 1.6.0",
+ "alloy-sol-types 1.6.0",
  "derive_more 2.1.1",
  "op-revm",
  "serde",
@@ -2153,10 +2205,10 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "anyhow",
  "kona-protocol",
  "once_cell",
@@ -2168,14 +2220,14 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
- "alloy-serde 2.0.4",
- "alloy-sol-types 1.5.7",
+ "alloy-serde 2.0.5",
+ "alloy-sol-types 1.6.0",
  "async-trait",
  "derive_more 2.1.1",
  "kona-genesis",
@@ -2190,14 +2242,14 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie",
  "op-alloy-rpc-types-engine",
@@ -2207,9 +2259,9 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "async-trait",
  "thiserror 2.0.18",
  "tracing",
@@ -2218,13 +2270,13 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-op-evm",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-trie",
  "ark-bls12-381",
@@ -2254,13 +2306,13 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-op-evm",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
@@ -2286,17 +2338,17 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "ambassador",
  "async-trait",
  "brotli",
@@ -2316,14 +2368,14 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-chains",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-op-hardforks",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "kona-genesis",
  "lazy_static",
  "serde",
@@ -2334,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "async-trait",
  "buddy_system_allocator",
@@ -2346,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",
@@ -2519,6 +2571,17 @@ name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2735,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "op-alloy-consensus",
 ]
@@ -2743,14 +2806,14 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "bytes",
  "derive_more 2.1.1",
  "reth-codecs",
@@ -2761,14 +2824,14 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-network-primitives",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "derive_more 2.1.1",
  "op-alloy-consensus",
  "serde",
@@ -2779,14 +2842,14 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
- "alloy-primitives 1.5.7",
+ "alloy-eips 2.0.5",
+ "alloy-primitives 1.6.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "alloy-serde 2.0.4",
+ "alloy-serde 2.0.5",
  "op-alloy-consensus",
  "serde",
  "sha2 0.10.9",
@@ -2796,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.6.0#6f38da950f0aced2758a56aa60c2f53340a44ead"
 dependencies = [
  "auto_impl",
  "revm",
@@ -2814,9 +2877,9 @@ name = "optimism-derivation"
 version = "0.1.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-op-evm",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "ark-ff",
  "async-trait",
  "hashbrown 0.16.0",
@@ -2842,7 +2905,7 @@ name = "optimism-elc"
 version = "0.1.1"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "ethereum-consensus",
  "ethereum-light-client-verifier",
  "kona-protocol",
@@ -3363,9 +3426,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -3563,7 +3626,7 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
- "alloy-primitives 1.5.7",
+ "alloy-primitives 1.6.0",
  "num_enum",
  "once_cell",
  "serde",
@@ -3965,7 +4028,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -4210,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -4502,9 +4575,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "1.0.2"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives 1.5.7",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2190,12 +2190,12 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-primitives 1.5.7",
  "async-trait",
@@ -2218,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-chains",
  "alloy-eips 2.0.4",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "async-trait",
  "buddy_system_allocator",
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",
@@ -2735,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "op-alloy-consensus",
 ]
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2761,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-client%2Fv1.5.1#fbbf9089d06952b441535aa9f2d0f897636baf93"
+source = "git+https://github.com/ethereum-optimism/optimism?rev=kona-node%2Fv1.5.2#a5f807798b0896becd497d27b92afe911b088ad4"
 dependencies = [
  "auto_impl",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,21 @@ ethereum-consensus = { git = "https://github.com/datachainlab/ethereum-light-cli
 ethereum-light-client-verifier = { git = "https://github.com/datachainlab/ethereum-light-client-rs", rev = "v0.2.0", default-features = false }
 
 # Kona
-kona-client = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-proof = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-preimage = {git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-executor = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-driver = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-genesis = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-protocol = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-derive = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
-kona-registry = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-client/v1.5.1", default-features = false }
+kona-client = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-proof = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-preimage = {git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-executor = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-driver = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-genesis = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-protocol = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-derive = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-registry = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
 
 # Alloy
 alloy-consensus = { version = "2.0.4", default-features = false }
 alloy-primitives = { version = "1.5.6", default-features = false }
 alloy-eips = { version = "2.0.4", default-features = false }
-alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", rev = "kona-client/v1.5.1", default-features = false }
+alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", rev = "kona-node/v1.5.2", default-features = false }
 
 # Cryptography
 sha2 = { version = "0.10.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,21 @@ ethereum-consensus = { git = "https://github.com/datachainlab/ethereum-light-cli
 ethereum-light-client-verifier = { git = "https://github.com/datachainlab/ethereum-light-client-rs", rev = "v0.2.0", default-features = false }
 
 # Kona
-kona-client = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-proof = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-preimage = {git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-executor = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-driver = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-genesis = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-protocol = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-derive = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
-kona-registry = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.5.2", default-features = false }
+kona-client = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-proof = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-preimage = {git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-executor = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-driver = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-genesis = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-protocol = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-derive = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
+kona-registry = { git="https://github.com/ethereum-optimism/optimism", rev= "kona-node/v1.6.0", default-features = false }
 
 # Alloy
-alloy-consensus = { version = "2.0.4", default-features = false }
-alloy-primitives = { version = "1.5.6", default-features = false }
-alloy-eips = { version = "2.0.4", default-features = false }
-alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", rev = "kona-node/v1.5.2", default-features = false }
+alloy-consensus = { version = "2.0.5", default-features = false }
+alloy-primitives = { version = "1.6.0", default-features = false }
+alloy-eips = { version = "2.0.5", default-features = false }
+alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", rev = "kona-node/v1.6.0", default-features = false }
 
 # Cryptography
 sha2 = { version = "0.10.8", default-features = false }

--- a/derivation/src/oracle.rs
+++ b/derivation/src/oracle.rs
@@ -297,8 +297,8 @@ mod test {
     use alloc::vec;
     use alloy_eips::eip4844::{BYTES_PER_COMMITMENT, FIELD_ELEMENTS_PER_BLOB};
     use alloy_primitives::keccak256;
-    use hashbrown::HashMap;
     use ark_ff::{BigInteger, PrimeField};
+    use hashbrown::HashMap;
     use hashbrown::HashSet;
     use kona_preimage::{PreimageKey, PreimageKeyType};
     use kona_proof::l1::ROOTS_OF_UNITY;

--- a/derivation/src/oracle.rs
+++ b/derivation/src/oracle.rs
@@ -297,7 +297,7 @@ mod test {
     use alloc::vec;
     use alloy_eips::eip4844::{BYTES_PER_COMMITMENT, FIELD_ELEMENTS_PER_BLOB};
     use alloy_primitives::keccak256;
-    use alloy_primitives::map::HashMap;
+    use hashbrown::HashMap;
     use ark_ff::{BigInteger, PrimeField};
     use hashbrown::HashSet;
     use kona_preimage::{PreimageKey, PreimageKeyType};


### PR DESCRIPTION
Update kona dependencies and sync alloy versions.